### PR TITLE
Link zur Lizenz lieber https:// als http://

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 // init leaflet map
 var map = L.map('map').setView([49.47704787438876, 8.5638427734375], 10);
 L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors <br/> Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors <br/> Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
 }).addTo(map);
 
 var geojson;


### PR DESCRIPTION
Besser das sicherere Hypertext-Übertragungsprotokoll nutzen, auch wenn dafür der Link länger wird.